### PR TITLE
Migrate from libsnooze

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,8 +6,7 @@
 	"copyright": "Copyright © 2023, Tristan B. Kildaire",
 	"dependencies": {
 		"dlog": ">=0.3.19",
-		"eventy": ">=0.4.0",
-		"libsnooze": ">=1.3.0-beta"
+		"eventy": ">=0.4.0"
 	},
 	"description": "A sane IRC framework for the D language",
 	"license": "LGPL-3.0",

--- a/source/birchwood/client/client.d
+++ b/source/birchwood/client/client.d
@@ -906,11 +906,6 @@ public class Client : Thread
                 // TODO: Could deallocate here
                 throw new BirchwoodException(ErrorType.INTERNAL_FAILURE, e.toString());
             }
-            catch(SnoozeError e)
-            {
-                // TODO: Coudl deallocate here
-                throw new BirchwoodException(ErrorType.INTERNAL_FAILURE, e.toString());
-            }
         }
         // TODO: Do actual liveliness check here
         else

--- a/source/birchwood/client/client.d
+++ b/source/birchwood/client/client.d
@@ -20,8 +20,6 @@ import birchwood.client.receiver : ReceiverThread;
 import birchwood.client.sender : SenderThread;
 import birchwood.client.events;
 
-import libsnooze.exceptions : SnoozeError;
-
 import dlog;
 
 package __gshared Logger logger;

--- a/source/birchwood/client/receiver.d
+++ b/source/birchwood/client/receiver.d
@@ -10,10 +10,6 @@ import core.sync.mutex : Mutex;
 
 import eventy : EventyEvent = Event;
 
-// TODO: Examine the below import which seemingly fixes stuff for libsnooze
-import libsnooze.clib;
-import libsnooze;
-
 import birchwood.client;
 import birchwood.protocol.messages : Message, decodeMessage;
 import std.string : indexOf;

--- a/source/birchwood/client/sender.d
+++ b/source/birchwood/client/sender.d
@@ -8,10 +8,6 @@ import core.thread : Thread, dur;
 import std.container.slist : SList;
 import core.sync.mutex : Mutex;
 
-// TODO: Examine the below import which seemingly fixes stuff for libsnooze
-import libsnooze.clib;
-import libsnooze;
-
 import birchwood.client;
 
 version(unittest)


### PR DESCRIPTION
## Purpose

No longer want to use `libsnooze`. A condition variable with a mutex is safer with `futex` etc. Libsnooze had an FD and yeah, stuff could go wrong if a use closed those.

## Todo :writing_hand: 

- [ ] Receiver
    - [x] Migrate to periodic wakeup mechanism with on-demand wait when blocked
- [ ]  Sender
    - [x] Migrate to periodic wakeup mechanism with on-demand wait when blocked